### PR TITLE
Sign artifacts on release only part2

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -39,9 +39,6 @@ jobs:
 
   publishingConsumingPluginTest:
     runs-on: ubuntu-latest
-    env:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,8 @@ gradlePlugin {
         id = "com.ioki.sentry.proguard"
         implementationClass = "com.ioki.sentry.proguard.gradle.plugin.SentryProguardGradlePlugin"
         displayName = "SentryProguardGradlePlugin"
-        description = "A Gradle plugin that generated UUIDs, add it to your AndroidManifest.xml and uploads the UUID together with the generated mapping file to Sentry."
+        description =
+            "A Gradle plugin that generated UUIDs, add it to your AndroidManifest.xml and uploads the UUID together with the generated mapping file to Sentry."
     }
 }
 
@@ -112,7 +113,7 @@ kotlin.jvmToolchain(17)
 signing {
     val signingKey = System.getenv("GPG_SIGNING_KEY")
     val signingPassword = System.getenv("GPG_SIGNING_PASSWORD")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
     isRequired = hasProperty("GPG_SIGNING_REQUIRED")
+    if (isRequired) useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications)
 }


### PR DESCRIPTION
There were failing tests.
See https://github.com/ioki-mobility/SentryProguardGradlePlugin/pull/78

This is because just setting `isRequired = hasProperty("GPG_SIGNING_REQUIRED")` is not enough.
We also have to disable the "signing part".
More information can also be found in [this Gradle slack thread](https://gradle-community.slack.com/archives/CAHSN3LDN/p1704879721497599).

Related to already clsoed ticket: #75 